### PR TITLE
Removed ambiguity caused by old mix.format

### DIFF
--- a/lib/monad/law.ex
+++ b/lib/monad/law.ex
@@ -26,6 +26,6 @@ defmodule Monad.Law do
   # (m >>= f) >>= g ≡ m >>= ( \x -> (f x >>= g) )
   @doc false
   def associativity?(monad, fun1, fun2) do
-    monad ~>> fun1 ~>> fun2 == monad ~>> &(fun1.(&1) ~>> fun2)
+    monad ~>> fun1 ~>> fun2 == monad ~>> (&(fun1.(&1) ~>> fun2))
   end
 end

--- a/test/list_test.exs
+++ b/test/list_test.exs
@@ -44,15 +44,15 @@ defmodule List.Test do
   end
 
   test "bind many" do
-    assert ["Billy", "Timmy"] ~>> &["Hello, #{&1}"] == ["Hello, Billy", "Hello, Timmy"]
+    assert ["Billy", "Timmy"] ~>> (&["Hello, #{&1}"]) == ["Hello, Billy", "Hello, Timmy"]
   end
 
   test "bind flatten" do
-    assert ["hello"] ~>> &[&1, &1] == ["hello", "hello"]
+    assert ["hello"] ~>> (&[&1, &1]) == ["hello", "hello"]
   end
 
   test "bind flatten many" do
-    assert ["hello", "goodbye"] ~>> &[&1, &1] == ["hello", "hello", "goodbye", "goodbye"]
+    assert ["hello", "goodbye"] ~>> (&[&1, &1]) == ["hello", "hello", "goodbye", "goodbye"]
   end
 
   test "fmap zero" do

--- a/test/maybe_test.exs
+++ b/test/maybe_test.exs
@@ -92,8 +92,8 @@ defmodule Maybe.Test do
   end
 
   test "bind" do
-    assert some(42) ~>> &(some(&1) |> unwrap! == 42)
-    assert some(42) ~>> &(some(&1 * 2) |> unwrap! == 84)
-    assert some(42) ~>> &(some(&1 * &1) |> unwrap! == 1764)
+    assert some(42) ~>> (&some(&1)) |> unwrap! == 42
+    assert some(42) ~>> (&some(&1 * 2)) |> unwrap! == 84
+    assert some(42) ~>> (&some(&1 * &1)) |> unwrap! == 1764
   end
 end

--- a/test/monad_test.exs
+++ b/test/monad_test.exs
@@ -7,9 +7,9 @@ defmodule Monad.Test do
   doctest Monad.Behaviour
 
   test "bind" do
-    assert 42 ~>> &(&1 == 42)
-    assert 42 ~>> &(&1 * 2 == 84)
-    assert 42 ~>> &(&1 * &1 == 1764)
+    assert 42 ~>> (& &1) == 42
+    assert 42 ~>> (&(&1 * 2)) == 84
+    assert 42 ~>> (&(&1 * &1)) == 1764
   end
 
   test "fmap one" do

--- a/test/result_test.exs
+++ b/test/result_test.exs
@@ -54,9 +54,9 @@ defmodule Result.Test do
   end
 
   test "bind" do
-    assert success(42) ~>> &(success(&1) |> unwrap! == 42)
-    assert success(42) ~>> &(success(&1 * 2) |> unwrap! == 84)
-    assert success(42) ~>> &(success(&1 * &1) |> unwrap! == 1764)
+    assert success(42) ~>> (&success(&1)) |> unwrap! == 42
+    assert success(42) ~>> (&success(&1 * 2)) |> unwrap! == 84
+    assert success(42) ~>> (&success(&1 * &1)) |> unwrap! == 1764
   end
 
   test "fmap one" do

--- a/test/writer_test.exs
+++ b/test/writer_test.exs
@@ -26,15 +26,15 @@ defmodule Writer.Test do
   end
 
   test "bind once" do
-    writer = writer(42) ~>> &writer(&1, "I did it")
+    writer = writer(42) ~>> (&writer(&1, "I did it"))
     assert writer == writer(42, "I did it")
   end
 
   test "bind twice with string monoid" do
     writer =
       writer(42)
-      ~>> &writer(&1 * 2, "Double")
-      ~>> &writer(&1 * 3, "Triple")
+      ~>> (&writer(&1 * 2, "Double"))
+      ~>> (&writer(&1 * 3, "Triple"))
 
     assert writer == writer(252, "DoubleTriple")
   end
@@ -42,8 +42,8 @@ defmodule Writer.Test do
   test "bind twice with array monoid" do
     writer =
       writer(42)
-      ~>> &writer(&1 * 2, ["Double"])
-      ~>> &writer(&1 * 3, ["Triple"])
+      ~>> (&writer(&1 * 2, ["Double"]))
+      ~>> (&writer(&1 * 3, ["Triple"]))
 
     assert writer == writer(252, ["Double", "Triple"])
   end


### PR DESCRIPTION
The previous mix format commit introduced some ambiguity that causes some tests to fail.

- Elixir v1.12
- Possibly related: https://github.com/elixir-lang/elixir/issues/7412

This commit removes the ambiguity and re-runs a newer version of the formatter. 

All seems well.